### PR TITLE
Updated java dependency to openjdk@8

### DIFF
--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -11,7 +11,7 @@ class ElasticsearchAT24 < Formula
 
   deprecate! :date => "2018-02-28"
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"


### PR DESCRIPTION
This is a very simple change to dependencies because a base install of Homebrew and ruby is now causing issues for other repos as well. [Same issue at Facebook](https://github.com/facebook/homebrew-fb/pull/47)

### I received this error when trying to install:
```bash
Error: Calling depends_on :java is disabled! Use depends_on "openjdk@11", depends_on "openjdk@8" or depends_on "openjdk" instead.
```

### My environment:

- Homebrew 2.7.2
- ruby 2.4.6p354 (2019-04-01 revision 67394) [x86_64-darwin20]

I presume this fix would be fine with whatever versions are installed for you, however, please double-check.